### PR TITLE
It is not possible to handle SIGKILL

### DIFF
--- a/pkg/system/signal.go
+++ b/pkg/system/signal.go
@@ -60,7 +60,7 @@ func NewSignals() *Signals {
 		interrupt: make(chan os.Signal, 1),
 		quit:      make(chan struct{}, 1),
 
-		shutdown:    []os.Signal{syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM},
+		shutdown:    []os.Signal{syscall.SIGINT, syscall.SIGTERM},
 		reload:      []os.Signal{syscall.SIGHUP},
 		maintenance: []os.Signal{syscall.SIGUSR1},
 	}

--- a/pkg/system/signal_test.go
+++ b/pkg/system/signal_test.go
@@ -54,7 +54,6 @@ func TestSignals(t *testing.T) {
 	shutdownSignals := signals.Get(Shutdown)
 	verifySignal(t, syscall.SIGTERM, shutdownSignals, Shutdown)
 	verifySignal(t, syscall.SIGINT, shutdownSignals, Shutdown)
-	verifySignal(t, syscall.SIGKILL, shutdownSignals, Shutdown)
 	reloadSignals := signals.Get(Reload)
 	verifySignal(t, syscall.SIGHUP, reloadSignals, Reload)
 	maintenanceSignals := signals.Get(Maintenance)


### PR DESCRIPTION
As we already discussed, in the case of `SIGKILL` the application will be terminated immediately and it is not possible to catch `SIGKILL`.

Thanks.